### PR TITLE
RandomSmith - Changes to allow user defined pins to be supplied

### DIFF
--- a/I2CBase.py
+++ b/I2CBase.py
@@ -1,0 +1,22 @@
+class I2CBase:
+    """The interface for the unified I2C library.
+       Allows sensor libraries to abstract away 
+       the differing I2C library apis for each microcontroller
+       Ideally only add methods that can be supported on all platforms directly
+       or by translating to other method calls that do exist
+    """
+    
+    def writeto_mem(self, addr, memaddr, buf, *, addrsize=8):
+        raise NotImplementedError("writeto_mem")
+
+    def readfrom_mem(self, addr, memaddr, nbytes, *, addrsize=8):
+        raise NotImplementedError("readfrom_mem")
+
+    def write(self, addr, buf, stop=True):
+        raise NotImplementedError("write")
+
+    def read(self, addr, nbytes, stop=True):
+        raise NotImplementedError("read")
+
+    def __init__(self, bus=0, freq=None, sda=None, scl=None):
+        raise NotImplementedError("__init__")

--- a/I2CUnifiedMachine.py
+++ b/I2CUnifiedMachine.py
@@ -1,0 +1,38 @@
+from machine import I2C
+from I2CBase import I2CBase
+
+class I2CUnifiedMachine(I2CBase):
+    """An implementation of I2CBase for boards such as 
+       Raspberry Pi Pico and others
+       All calls are handed off to the machine.ic2
+    """
+    def __init__(self, bus=0, freq=None, sda=None, scl=None):
+        """
+        Parameters
+        ----------
+        bus : int
+            Some boards have more than one bus
+            example: 0
+        freq : int
+            frequency of data bit transfer in bits per second
+            example: 400000    
+        sda : enum
+            Some boards allow the data (sda) pin to be changed
+            value is dependent on the board
+            example: Pin(8)
+        scl : enum
+            Some boards allow the clock (scl) pin to be changed
+            value is dependent on the board
+            example: Pin(9)
+        """
+        if freq is not None and sda is not None and scl is not None:
+            print("Using supplied freq, sda and scl to create machine I2C")
+            self.i2c = I2C(bus, freq=freq, sda=sda, scl=scl)
+        else: 
+            print("Using default machine I2C")
+            self.i2c = I2C(bus)
+
+        self.writeto_mem = self.i2c.writeto_mem 
+        self.readfrom_mem = self.i2c.readfrom_mem   
+        self.write = self.i2c.writeto
+        self.read = self.i2c.readfrom

--- a/I2CUnifiedMicroBit.py
+++ b/I2CUnifiedMicroBit.py
@@ -1,0 +1,55 @@
+import microbit
+from microbit import i2c
+from I2CBase import I2CBase
+
+
+class I2CUnifiedMicroBit(I2CBase):
+    """An implementation of I2CBase for the BBC micro:bit
+       The micro:bit does not have implementations of writeto_mem or readfrom_mem
+       and so implements these as calls to write and read"""
+
+    def writeto_mem(self, addr, memaddr, buf, *, addrsize=8):
+        # micro:bit does not contain a writeto_mem function
+        # implementing in terms of the provided microbit.i2c.write
+        ad = memaddr.to_bytes(addrsize // 8, 'big')  # pad address for eg. 16 bit
+        self.write(addr, ad + buf)
+
+    def readfrom_mem(self, addr, memaddr, nbytes, *, addrsize=8):
+        # micro:bit does not contain a readfrom_mem function
+        # implementing in terms of the provided microbit.i2c.read
+        ad = memaddr.to_bytes(addrsize // 8, 'big')  # pad address for eg. 16 bit
+        self.write(addr, ad)
+        return self.read(addr, nbytes)
+
+    def write(self, addr, buf, stop=True):
+        repeat = not stop
+        i2c.write(addr, buf, repeat)
+
+    def read(self, addr, nbytes, stop=True):
+        repeat = not stop
+        return i2c.read(addr, nbytes, repeat)
+
+    def __init__(self, bus=0, freq=None, sda=None, scl=None):
+        """
+        Parameters
+        ----------
+        bus : int
+            The micro:bit has a single I2C bus 
+            and this value is ignored
+        freq : int, optional
+            frequency of data bit transfer in bits per second    
+            example 400000    
+        sda : enum
+            While the micro:bit documentation suggests that the sda 
+            pin can be changed, in practice it does not like it
+            so this value is ignored
+            sda is pin20 on the micro:bit
+        scl : enum
+            While the micro:bit documentation suggests that the scl 
+            pin can be changed, in practice it does not like it
+            so this value is ignored
+            scl is pin19 on the micro:bit
+        """
+        if freq is not None:
+            print("Initialising I2C freq to {}".format(freq))
+            microbit.i2c.init(freq=freq)

--- a/PiicoDev_Unified.py
+++ b/PiicoDev_Unified.py
@@ -3,55 +3,47 @@ PiicoDev.py: Unifies I2C drivers for different builds of micropython
 """
 
 import os
-_SYSNAME = os.uname().sysname
 
-# Run correct imports for different micropython ports
-if _SYSNAME == 'microbit':
-    from microbit import i2c
-else: # Vanilla machine implementation
-    from machine import I2C
-    i2c = I2C(0)
-    
+def create_unified_i2c(bus=0, freq=None, sda=None, scl=None):
+    """The parameters passed are to override the defaults
+    only supply parameters if you wish to override the defaults 
+    for your board.
+    See the implementations such as I2CUnifiedMachine or 
+    I2CUnifiedMicroBit for more details on what can be changed.
 
-class PiicoDev_Unified_I2C(object):
-    
-    # Implement machine library's Memory operations as standard bus operations (microbit-friendly)
-    def writeto_mem(self, addr, memaddr, buf, *, addrsize=8):
-        ad = memaddr.to_bytes(addrsize//8,'big') # pad address for eg. 16 bit
-        self.UnifiedWrite(addr, ad+buf)
-        
-    def readfrom_mem(self, addr, memaddr, nbytes, *, addrsize=8):
-        ad = memaddr.to_bytes(addrsize//8,'big') # pad address for eg. 16 bit
-        self.UnifiedWrite(addr, ad) # address pointer
-        return self.UnifiedRead(addr, nbytes)
-    
-    def UnifiedWrite(self, addr, buf, stop=True):
-        if _SYSNAME == 'microbit':
-            repeat = not(stop)
-            self.i2c.write(addr, buf, repeat)
-        else:
-            self.i2c.writeto(addr, buf, stop)    
-    
-    def UnifiedRead(self, addr, nbytes, stop=True):
-        if _SYSNAME == 'microbit':
-            repeat = not(stop)
-            return self.i2c.read(addr, nbytes, repeat)
-        else:
-            return self.i2c.readfrom(addr, nbytes, stop)
-    
-    def __init__(self):
-        self.i2c = i2c
-        
-        if _SYSNAME == 'microbit':
-            self.sysPort = 'microbit'
-#             self.UnifiedWrite = i2c.write
-#             self.UnifiedRead = i2c.read
-            self.writeto_mem = self.writeto_mem
-            self.readfrom_mem = self.readfrom_mem
-            
-        else:
-            self.sysPort = 'machine'
-#             self.UnifiedWrite = i2c.writeto
-#             self.UnifiedRead = i2c.readfrom
-            self.writeto_mem = i2c.writeto_mem # use machine's built-ins
-            self.readfrom_mem = i2c.readfrom_mem
+    To add a unified I2C to your sensor library, add a named 
+    i2c paramter to the __init__ method.
+    For example:
+        def __init__(self, address=0x29, i2c=None):
+            if i2c is not None:
+                print("Using supplied i2c")
+                self.i2c = i2c
+            else:
+                self.i2c = create_unified_i2c()
+
+    This means that the user in most cases does not need to 
+    worry about the I2C settings if the wish to connect the 
+    sensor to the default scl or sda pins of the microcontroller.
+    For example for the Raspberry Pi Pico and the BBC micro:bit:
+
+    from PiicoDev_VL53L1X import PiicoDev_VL53L1X
+
+    laser = PiicoDev_VL53L1X()
+
+    Those users that want to change the pins can instead make a 
+    call to create_unified_i2c themselves and pass that in
+    to the sensor api constructor.
+    For example for the Raspberry Pi Pico:
+
+    from PiicoDev_VL53L1X import PiicoDev_VL53L1X
+
+    laser = PiicoDev_VL53L1X(i2c=create_unified_i2c(freq=400000, sda=Pin(0), scl=Pin(1)))
+    """
+    _SYSNAME = os.uname().sysname
+    if _SYSNAME == 'microbit':
+        from I2CUnifiedMicroBit import I2CUnifiedMicroBit
+        i2c = I2CUnifiedMicroBit(bus, freq, sda, scl)
+    else:
+        from I2CUnifiedMachine import I2CUnifiedMachine
+        i2c = I2CUnifiedMachine(bus, freq, sda, scl)
+    return i2c

--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # Core Electronics Unified PiicoDev Library
 *Unifies the I2C drivers for different implementations of MicroPython*
+
+## Adding the Unified I2C api to your sensor library api
+To add the unified I2C to your sensor library api add a named i2c paramter to the __init__ method.
+    
+For example:
+```
+# don't create a global i2c here, creates issues trying to pass in a user created i2c
+class PiicoDev_VL53L1X:
+
+    def __init__(self, address=0x29, i2c=None):
+        if i2c is not None:
+            print("Using supplied i2c")
+            self.i2c = i2c
+        else:
+            self.i2c = create_unified_i2c()
+```
+This means that the user in most cases does not need to 
+worry about the I2C settings if the wish to connect the 
+sensor to the default scl or sda pins of the microcontroller.
+
+# Documentation to add to PiicoDev_VL53L1X
+## User Examples
+
+### User example of defaults for Raspberry Pi Pico and the BBC micro:bit - same user code for both
+Raspberry Pi Pico defaults
+* sda pin 8
+* scl pin 9
+
+BBC micro:bit
+* sda pin 20
+* scl pin 19
+
+```
+from PiicoDev_VL53L1X import PiicoDev_VL53L1X
+from utime import sleep_ms
+
+laser = PiicoDev_VL53L1X()
+
+while True:
+    dist = laser.read() # read the distance in millimetres
+    print("{:4d} | ".format(dist))
+    sleep_ms(1000)
+```
+    
+### Custom frequency for BBC micro:bit
+```
+from PiicoDev_VL53L1X import PiicoDev_VL53L1X
+from utime import sleep_ms
+from PiicoDev_Unified import create_unified_i2c
+
+laser = PiicoDev_VL53L1X(i2c=create_unified_i2c(freq=400000))
+
+while True:
+    dist = laser.read() # read the distance in millimetres
+    print("{:4d} | ".format(dist))
+    sleep_ms(1000)
+```
+
+### Custom frequency, scl and sda pins for the Raspberry Pi Pico:
+```
+from PiicoDev_VL53L1X import PiicoDev_VL53L1X
+from utime import sleep_ms
+from machine import Pin
+from PiicoDev_Unified import create_unified_i2c
+
+i2cmod=create_unified_i2c(freq=400000, sda=Pin(0), scl=Pin(1))
+laser = PiicoDev_VL53L1X(i2c=i2cmod)
+
+while True:
+    dist = laser.read() # read the distance in millimetres
+    print("{:4d} | ".format(dist))
+    sleep_ms(1000)    
+    
+``` 


### PR DESCRIPTION
Hi,

I was trying to use the CE-PiicoDev-Unified and CE-PiicoDev-VL53L1X-MicroPython-Module libraries
but wanted to override the pins, which I wasn't sure If I could do due to the global variables for i2c.

I am fairly new to Python and MicroPython and microcontrollers, but developer by trade.
Feel free to use the code in the pull request if you like. It will provide separation of the code between different flavours of micropython and or boards.
It has an implementation for I2CUnifiedMicroBit which only includes code that is relevant to the micro:bit
and an implementation for IC2 from the machine library which should suit other boards. If it doesn't then it is easy to add extra classes like for the microbit or machine and adding extra classes means that you would be less likely to introduce errors because you will not likely be changing the microbit code when modifying or adding new boards - hope that makes sense.

I have also added some code in the readme.md file that shows how you would add the unified lib to your sensor so that users can use the defaults, but those users that need to change the pins can pass in pin details too...: i.e. 

from PiicoDev_Unified import create_unified_i2c
class PiicoDev_VL53L1X:

    def __init__(self, address=0x29, i2c=None):
        if i2c is not None:
            print("Using supplied i2c")
            self.i2c = i2c
        else:
            self.i2c = create_unified_i2c()

Saw the youtube video where Michael was asking about if the unified style code was a good idea
this will allow you extend more easily when new edge cases arise - https://youtu.be/2oinDOsrIO8?t=488