### PR TITLE
Initial Raspberry Pi (SBC) support

### DIFF
--- a/PiicoDev_Unified.py
+++ b/PiicoDev_Unified.py
@@ -8,7 +8,7 @@ _SYSNAME = os.uname().sysname
 # Run correct imports for different micropython ports
 if _SYSNAME == 'microbit':
     from microbit import i2c
-    import utime.sleep_ms
+    from utime import sleep_ms as usleep_ms
     
 elif _SYSNAME == 'Linux': # For Raspberry Pi SBC
     from smbus2 import SMBus
@@ -90,7 +90,7 @@ class PiicoDev_Unified_I2C(object):
             self.writeto_mem = self.writeto_mem
             self.readfrom_mem = self.readfrom_mem
        
-        if _SYSNAME == 'Linux':
+        elif _SYSNAME == 'Linux':
             self.sysPort = 'linux'
         
         else:

--- a/PiicoDev_Unified.py
+++ b/PiicoDev_Unified.py
@@ -48,7 +48,7 @@ class PiicoDev_Unified_I2C(object):
             d = int.from_bytes(data, 'big')
             self.i2c.write_byte_data(addr, r, d)
         else:
-            self.i2c.UnifiedWrite(addr, reg + data)
+            i2c.UnifiedWrite(addr, reg + data)
             
             
     def read16(self, addr, reg):

--- a/PiicoDev_Unified.py
+++ b/PiicoDev_Unified.py
@@ -5,9 +5,19 @@ PiicoDev.py: Unifies I2C drivers for different builds of micropython
 import os
 _SYSNAME = os.uname().sysname
 
+def sleep_ms2s(t):
+    sleep(t/1000)
+
 # Run correct imports for different micropython ports
 if _SYSNAME == 'microbit':
     from microbit import i2c
+    
+elif _SYSNAME == 'Linux': # For Raspberry Pi SBC
+    from smbus2 import SMBus
+    from time import sleep
+    i2c = SMBus(1)
+    sleep_ms = sleep_ms2s
+    
 else: # Vanilla machine implementation
     from machine import I2C
     i2c = I2C(0)
@@ -30,12 +40,40 @@ class PiicoDev_Unified_I2C(object):
             repeat = not(stop)
             self.i2c.write(addr, buf, repeat)
         else:
-            self.i2c.writeto(addr, buf, stop)    
+            self.i2c.writeto(addr, buf, stop)
+    
+    def write8(self, addr, reg, data):
+        if _SYSNAME == 'Linux':
+            r = int.from_bytes(reg, 'big')
+            d = int.from_bytes(data, 'big')
+            self.i2c.write_byte_data(addr, r, d)
+        else:
+            self.i2c.UnifiedWrite(addr, reg + data)
+            
+            
+    def read16(self, addr, reg):
+        if _SYSNAME == 'Linux':
+            regInt = int.from_bytes(reg, 'big')
+            return self.i2c.read_word_data(addr, regInt).to_bytes(2, byteorder='little', signed=False)
+        else:
+            self.UnifiedWrite(addr, reg, stop=False)
+            return self.UnifiedRead(addr, 2)
     
     def UnifiedRead(self, addr, nbytes, stop=True):
         if _SYSNAME == 'microbit':
             repeat = not(stop)
             return self.i2c.read(addr, nbytes, repeat)
+        
+        elif _SYSNAME == 'Linux':
+            if nbytes == 2:
+                wordData = i2c.read_word_data(addr, 0x00).to_bytes(2, byteorder='little', signed=False)
+            data = bytearray([])
+            return data
+            for i in range(nbytes):
+                data += bytearray([i2c.read_byte(addr)])
+                print("    {}".format(data))
+            return data
+            
         else:
             return self.i2c.readfrom(addr, nbytes, stop)
     
@@ -44,14 +82,15 @@ class PiicoDev_Unified_I2C(object):
         
         if _SYSNAME == 'microbit':
             self.sysPort = 'microbit'
-#             self.UnifiedWrite = i2c.write
-#             self.UnifiedRead = i2c.read
             self.writeto_mem = self.writeto_mem
             self.readfrom_mem = self.readfrom_mem
-            
+        
+        if _SYSNAME == 'Linux':
+            self.sysPort = 'linux'
+#             self.writeto_mem = None # TODO
+#             self.readfrom_mem = None # TODO
+        
         else:
             self.sysPort = 'machine'
-#             self.UnifiedWrite = i2c.writeto
-#             self.UnifiedRead = i2c.readfrom
             self.writeto_mem = i2c.writeto_mem # use machine's built-ins
             self.readfrom_mem = i2c.readfrom_mem

--- a/PiicoDev_Unified.py
+++ b/PiicoDev_Unified.py
@@ -5,7 +5,7 @@ PiicoDev.py: Unifies I2C drivers for different builds of micropython
 import os
 _SYSNAME = os.uname().sysname
 
-def sleep_ms2s(t):
+def sleep_ms2s(t): # RPi SBC only has sleep[sec]
     sleep(t/1000)
 
 # Run correct imports for different micropython ports
@@ -63,16 +63,6 @@ class PiicoDev_Unified_I2C(object):
         if _SYSNAME == 'microbit':
             repeat = not(stop)
             return self.i2c.read(addr, nbytes, repeat)
-        
-        elif _SYSNAME == 'Linux':
-            if nbytes == 2:
-                wordData = i2c.read_word_data(addr, 0x00).to_bytes(2, byteorder='little', signed=False)
-            data = bytearray([])
-            return data
-            for i in range(nbytes):
-                data += bytearray([i2c.read_byte(addr)])
-                print("    {}".format(data))
-            return data
             
         else:
             return self.i2c.readfrom(addr, nbytes, stop)
@@ -82,13 +72,9 @@ class PiicoDev_Unified_I2C(object):
         
         if _SYSNAME == 'microbit':
             self.sysPort = 'microbit'
-            self.writeto_mem = self.writeto_mem
-            self.readfrom_mem = self.readfrom_mem
         
-        if _SYSNAME == 'Linux':
+        elif _SYSNAME == 'Linux':
             self.sysPort = 'linux'
-#             self.writeto_mem = None # TODO
-#             self.readfrom_mem = None # TODO
         
         else:
             self.sysPort = 'machine'

--- a/PiicoDev_Unified.py
+++ b/PiicoDev_Unified.py
@@ -48,7 +48,7 @@ class PiicoDev_Unified_I2C(object):
             d = int.from_bytes(data, 'big')
             self.i2c.write_byte_data(addr, r, d)
         else:
-            i2c.UnifiedWrite(addr, reg + data)
+            self.UnifiedWrite(addr, reg + data)
             
             
     def read16(self, addr, reg):


### PR DESCRIPTION
Include support for raspberry pi / SMBus. This has been battle-tested with TMP117 and VEML6030. Other device modules will need to be ported to use the Unified library.