### PR TITLE
Create pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[tool.poetry]
+name = "piicodev-unified"
+version = "1.10.1"
+description = "Drivers for the PiicoDev ecosystem of sensors and modules"
+authors = ["Core Electronics <production.inbox@coreelectronics.com.au>"]
+license = "MIT"
+readme = "README.md"
+classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: MicroPython",
+        "License :: OSI Approved :: MIT License",
+    ]
+
+packages = [
+    { include = "PiicoDev_Unified.py" }
+]
+
+[project.urls]
+Homepage = "https://github.com/CoreElectronics/CE-PiicoDev-Unified"
+Documentation = "https://github.com/CoreElectronics/CE-PiicoDev-Unified/blob/main/doc/METHODS.md"
+Repository = "https://github.com/CoreElectronics/CE-PiicoDev-Unified"
+Issues = "https://github.com/CoreElectronics/CE-PiicoDev-Unified/issues"
+#Changelog = "https://github.com/me/spam/blob/master/CHANGELOG.md"
+
+
+[tool.poetry.dependencies]
+python = ">=3.7"
+
+# Linux only
+smbus2 = { version = "*", markers = "sys_platform == 'linux'"}
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
What I am proposing is enabling the ability to add the git repos as a dependency to a project.

The inclusion of a pyproject.toml allows a project to be added as a dependency as shown:

![image](https://github.com/CoreElectronics/CE-PiicoDev-Unified/assets/22471382/43298552-923f-480f-9fb7-d895326c5037)

This is handy for "bleeding edge" work to be tested in projects (with developers being explicit that they are using unstable branches).  It also allows dependencies to be specified independent of the PyPI update cycle.  The reason I wanted to do this is so I can run code checkers aginst my updates of the PiicoDev-RGB code which required PiicoDev-Unified to be installed.

The current works fine with python-poetry.  It also works with pip as demonstrated below:



```bash
 [gary@fedora pythonProject]$ pip install  git+https://github.com/garynthompson/CE-PiicoDev-Unified.git#main
Collecting git+https://github.com/garynthompson/CE-PiicoDev-Unified.git#main
  Cloning https://github.com/garynthompson/CE-PiicoDev-Unified.git to /tmp/pip-req-build-aye4ry4w
  Running command git clone --filter=blob:none --quiet https://github.com/garynthompson/CE-PiicoDev-Unified.git /tmp/pip-req-build-aye4ry4w
  Resolved https://github.com/garynthompson/CE-PiicoDev-Unified.git to commit 411b85f00ce9c46e9869ab70f290b8c76d6d4be4
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: piicodev-unified
  Building wheel for piicodev-unified (pyproject.toml) ... done
  Created wheel for piicodev-unified: filename=piicodev_unified-1.10.1-py3-none-any.whl size=5172 sha256=aecf7b8efd243a97fea65d6fe31ca1359c874d196e8e00c5ae06d21be4eeb0dd
  Stored in directory: /tmp/pip-ephem-wheel-cache-s23swkrz/wheels/a9/db/66/d97615cef5dbd431436f25c7e17782172ae588a01319fabac5
Successfully built piicodev-unified
Installing collected packages: piicodev-unified
Successfully installed piicodev-unified-1.10.1
```

I do realise that smbus2 hasn't been specified, I am happy to add the dependency for the linux platform (with pyproject.toml files I find it easier to create platform-specific dependencies).

I have not tested yet how this works in a micropython environment, I am still learning how package handling goes there and how it does not interact with the CPython world.
